### PR TITLE
v1.6.3

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -26,7 +26,7 @@ springVersion=6.1.3
 springBootVersion=3.2.3
 
 buildGroupId=com.onixbyte
-buildVersion=1.6.2
+buildVersion=1.6.3
 projectUrl=https://onixbyte.com/JDevKit
 projectGithubUrl=https://github.com/OnixByte/JDevKit
 licenseName=The Apache License, Version 2.0

--- a/simple-jwt-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
+++ b/simple-jwt-spring-boot-starter/src/main/resources/META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports
@@ -1,3 +1,2 @@
 com.onixbyte.simplejwt.autoconfiguration.GuidAutoConfiguration
 com.onixbyte.simplejwt.autoconfiguration.AuthzeroTokenResolverAutoConfiguration
-com.onixbyte.simplejwt.autoconfiguration.JjwtTokenResolverAutoConfiguration


### PR DESCRIPTION
# Fixes

- In the last upgrade, we removed `JjwtTokenResolver` since design matters, but forgot to remove `JjwtTokenResolverAutoConfiguration` in spring auto imports file that caused `FileNotFoundException` when all application starts.