### PR TITLE
fix: missing components for RSA key pair

### DIFF
--- a/key-pair-loader/src/main/java/com/onixbyte/security/KeyLoader.java
+++ b/key-pair-loader/src/main/java/com/onixbyte/security/KeyLoader.java
@@ -69,8 +69,8 @@ public interface KeyLoader {
     default String getRawContent(String pemKeyText) {
         // remove all unnecessary parts of the pem key text
         return pemKeyText
-                .replaceAll("-----BEGIN (EC )?(PRIVATE|PUBLIC) KEY-----", "")
-                .replaceAll("-----END (EC )?(PRIVATE|PUBLIC) KEY-----", "")
+                .replaceAll("-----BEGIN ((EC )|(RSA ))?(PRIVATE|PUBLIC) KEY-----", "")
+                .replaceAll("-----END ((EC )|(RSA ))?(PRIVATE|PUBLIC) KEY-----", "")
                 .replaceAll("\n", "");
     }
 


### PR DESCRIPTION
Updated the regex patterns in the `getRawContent` method to support both `EC` and `RSA` keys for the `BEGIN` and `END` markers.

